### PR TITLE
chore: fix gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,5 @@ node_modules
 
 # .env
 .env
-!.env.example
 .env.*
+!.env.example


### PR DESCRIPTION
heya :wave: thanks for the repo it's great

in `.gitignore`, the order was wrong so `.env.example` still gets excluded, here's a quick PR :wink: 